### PR TITLE
Initialize Hugo site for Tweed Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/public/
+/resources/
+/node_modules/
+.DS_Store
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# tweed.cloud
+# Tweed Cloud
+
+This repository contains the [Hugo](https://gohugo.io/) source for the Tweed Cloud website.
+
+## Development
+
+1. Install Hugo.
+2. Run `hugo server` to view the site locally.
+3. Run `hugo` to build the static files into the `public/` directory.
+
+The output is ready to deploy on platforms such as Cloudflare Pages.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,7 @@
+---
+title: 'Home'
+---
+
+Tweed Cloud is a small business by **Jordan David Evans** offering website design, hosting, and general web consultation services.
+
+For inquiries, please email [jordan@tweed.cloud](mailto:jordan@tweed.cloud).

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,7 @@
+---
+title: 'Contact'
+---
+
+**Jordan David Evans**
+
+Email: [jordan@tweed.cloud](mailto:jordan@tweed.cloud)

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,8 @@
+baseURL = 'https://tweed.cloud/'
+languageCode = 'en-us'
+title = 'Tweed Cloud'
+
+disableKinds = ['taxonomy', 'term']
+
+[params]
+  description = 'Website design, hosting, and consultation by Jordan David Evans.'

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+  {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
+  <style>
+    body{font-family:sans-serif;margin:0 auto;max-width:800px;padding:1rem;line-height:1.5}
+    header,footer{text-align:center}
+    nav a{margin:0 .5rem}
+  </style>
+</head>
+<body>
+  <header>
+    <h1><a href="/">{{ .Site.Title }}</a></h1>
+    <nav>
+      <a href="/">Home</a>
+      {{ range site.RegularPages }}
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+      {{ end }}
+    </nav>
+  </header>
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  <footer>
+    &copy; {{ now.Year }} {{ .Site.Title }}
+  </footer>
+</body>
+</html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,7 @@
+{{ define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+  <article>
+    <h2>{{ .Title }}</h2>
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,6 @@
+{{ define "title" }}{{ .Site.Title }}{{ end }}
+{{ define "main" }}
+  <section>
+    {{ .Content }}
+  </section>
+{{ end }}


### PR DESCRIPTION
## Summary
- set up Hugo configuration for Tweed Cloud with site metadata
- add home and contact pages highlighting services and contact info
- implement minimal layouts and documentation for Cloudflare Pages deployment

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68bf99292b248325904c53c295ae667f