### PR TITLE
Add SEO meta tags and navigation partials

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
-  {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
+  {{ partial "seo.html" . }}
   <style>
     body{font-family:sans-serif;margin:0 auto;max-width:800px;padding:1rem;line-height:1.5}
     header,footer{text-align:center}
@@ -12,20 +12,10 @@
   </style>
 </head>
 <body>
-  <header>
-    <h1><a href="/">{{ .Site.Title }}</a></h1>
-    <nav>
-      <a href="/">Home</a>
-      {{ range site.RegularPages }}
-      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-      {{ end }}
-    </nav>
-  </header>
+  {{ partial "header.html" . }}
   <main>
     {{ block "main" . }}{{ end }}
   </main>
-  <footer>
-    &copy; {{ now.Year }} {{ .Site.Title }}
-  </footer>
+  {{ partial "footer.html" . }}
 </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  &copy; {{ now.Year }} {{ .Site.Title }}
+</footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,9 @@
+<header>
+  <h1><a href="/">{{ .Site.Title }}</a></h1>
+  <nav>
+    <a href="/">Home</a>
+    {{ range .Site.RegularPages }}
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    {{ end }}
+  </nav>
+</header>

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,0 +1,24 @@
+{{ $desc := or .Params.description .Site.Params.description }}
+{{ $seotitle := .Site.Title }}
+{{ if not .IsHome }}{{ $seotitle = printf "%s | %s" .Title .Site.Title }}{{ end }}
+<meta name="description" content="{{ $desc }}">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="{{ .Permalink }}">
+<meta property="og:title" content="{{ $seotitle }}">
+<meta property="og:description" content="{{ $desc }}">
+<meta property="og:type" content="{{ if .IsHome }}website{{ else }}article{{ end }}">
+<meta property="og:url" content="{{ .Permalink }}">
+{{ with .Params.image }}<meta property="og:image" content="{{ . }}">
+<meta name="twitter:image" content="{{ . }}">{{ end }}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{{ $seotitle }}">
+<meta name="twitter:description" content="{{ $desc }}">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{{ if .IsHome }}WebSite{{ else }}WebPage{{ end }}",
+  "url": "{{ .Permalink }}",
+  "name": "{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}",
+  "description": "{{ $desc }}"
+}
+</script>


### PR DESCRIPTION
## Summary
- add SEO meta tags and JSON-LD schema
- extract header and footer into reusable partials with basic navigation
- update base layout to include SEO and layout partials

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68bf9d9819f0832599677900383afe87