### PR TITLE
Add about page with personal background

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,11 @@
+---
+title: 'About'
+---
+
+I have an avid interest in computers and online stuff in general.
+
+I am currently employed full time at Localsearch, a Gold Coast marketing agency, where I work in quality assurance for websites.
+
+I have creative interests in photography and game design.
+
+I hold a Certificate III in Information Technology from TAFE and possess extensive knowledge beyond that through self-teaching and constant learning.


### PR DESCRIPTION
## Summary
- add personal about page covering work, interests, and education

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68bf9feab3ac8325ab7309eaae39bcbd