### PR TITLE
Add social links to footer, About, and Contact pages

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -11,6 +11,8 @@ person:
   worksFor: "Localsearch"
   sameAs:
     - "https://github.com/JordanDavidEvans"
+    - "https://www.linkedin.com/in/jordan-evans-37a211212"
+    - "https://www.instagram.com/da_jordo/"
   knowsAbout:
     - "web accessibility"
     - "web performance"
@@ -43,4 +45,7 @@ Refining custom GA4 event tracking and diving deeper into automated accessibilit
 
 ## Want to collaborate?
 [View work](/) • [Hire me](/consultation) • [Say hi](/contact)
+
+### Follow me
+[LinkedIn](https://www.linkedin.com/in/jordan-evans-37a211212) · [Instagram](https://www.instagram.com/da_jordo/) · [GitHub](https://github.com/JordanDavidEvans/)
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -10,3 +10,8 @@ Email: [jordan@tweed.cloud](mailto:jordan@tweed.cloud)
 Phone: [0406860031](tel:0406860031)
 
 Location: Murwillumbah in the Northern Rivers region. I can meet locally or work remotely to assist clients wherever they are.
+
+### Social
+- [LinkedIn](https://www.linkedin.com/in/jordan-evans-37a211212)
+- [Instagram](https://www.instagram.com/da_jordo/)
+- [GitHub](https://github.com/JordanDavidEvans/)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,6 @@
 <footer>
-  &copy; {{ now.Year }} {{ .Site.Title }}
+  &copy; {{ now.Year }} {{ .Site.Title }} ·
+  <a href="https://www.linkedin.com/in/jordan-evans-37a211212" rel="me">LinkedIn</a> ·
+  <a href="https://www.instagram.com/da_jordo/" rel="me">Instagram</a> ·
+  <a href="https://github.com/JordanDavidEvans/" rel="me">GitHub</a>
 </footer>


### PR DESCRIPTION
## Summary
- Add LinkedIn, Instagram, and GitHub links to site footer
- Include same social links on About and Contact pages
- Confirmed site configuration uses https://tweed.cloud/ as base URL

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68bfa7284a6083259be0af796fc78574