### PR TITLE
feat: add old terminal loading effect

### DIFF
--- a/themes/tweed-90s/assets/js/terminal.js
+++ b/themes/tweed-90s/assets/js/terminal.js
@@ -1,0 +1,70 @@
+function typeNode(node, parent, done, speed) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent;
+    let i = 0;
+    (function type() {
+      if (i < text.length) {
+        parent.appendChild(document.createTextNode(text[i]));
+        i++;
+        setTimeout(type, speed);
+      } else {
+        done();
+      }
+    })();
+  } else if (node.nodeType === Node.ELEMENT_NODE) {
+    const el = document.createElement(node.tagName.toLowerCase());
+    for (const attr of node.attributes) {
+      el.setAttribute(attr.name, attr.value);
+    }
+    parent.appendChild(el);
+    let i = 0;
+    (function next() {
+      if (i < node.childNodes.length) {
+        typeNode(node.childNodes[i], el, () => {
+          i++;
+          next();
+        }, speed);
+      } else {
+        done();
+      }
+    })();
+  } else {
+    done();
+  }
+}
+
+function typeWriter(element, speed, callback) {
+  const clone = element.cloneNode(true);
+  element.innerHTML = "";
+  let i = 0;
+  (function next() {
+    if (i < clone.childNodes.length) {
+      typeNode(clone.childNodes[i], element, () => {
+        i++;
+        next();
+      }, speed);
+    } else if (callback) {
+      callback();
+    }
+  })();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.body.style.backgroundColor = "#0d0d0d";
+  document.body.style.color = "#00ff00";
+  document.body.style.fontFamily = "monospace";
+  const elements = [
+    document.querySelector('.site-header'),
+    document.querySelector('main'),
+    document.querySelector('.site-footer')
+  ].filter(Boolean);
+  let index = 0;
+  (function next() {
+    if (index < elements.length) {
+      typeWriter(elements[index], 20, () => {
+        index++;
+        next();
+      });
+    }
+  })();
+});

--- a/themes/tweed-90s/assets/scss/main.scss
+++ b/themes/tweed-90s/assets/scss/main.scss
@@ -6,9 +6,9 @@
 
 body {
   margin: 0;
-  font-family: var(--font-base);
-  background: var(--mint);
-  color: var(--navy);
+  font-family: monospace;
+  background: #0d0d0d;
+  color: #00ff00;
   line-height: 1.6;
 }
 
@@ -28,7 +28,7 @@ h2 { font-size: clamp(1.5rem, 5vw, 2.25rem); }
 h3 { font-size: clamp(1.25rem, 4vw, 1.75rem); }
 
 a {
-  color: var(--teal);
+  color: #00ff00;
   text-decoration: none;
 }
 
@@ -64,7 +64,7 @@ textarea:focus-visible {
 
 .site-header,
 .site-footer {
-  background: var(--mint-light-1);
+  background: #0d0d0d;
 }
 
 .site-header .container,

--- a/themes/tweed-90s/layouts/_default/baseof.html
+++ b/themes/tweed-90s/layouts/_default/baseof.html
@@ -6,6 +6,8 @@
   {{ partial "seo/head.html" . }}
   {{ $css := resources.Get "scss/main.scss" | toCSS | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+  {{ $js := resources.Get "js/terminal.js" | js.Build | minify | fingerprint }}
+  <script src="{{ $js.RelPermalink }}" defer></script>
 </head>
 <body class="{{ if .Site.Params.theme.retroMode }}retro {{ end }}{{ if .Site.Params.theme.showGradients }}gradients {{ end }}{{ if .Site.Params.theme.showPixelBorders }}pixel {{ end }}">
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- add terminal.js to render site content with a typewriter animation
- restyle page with green text on an off-black background
- include terminal script in base template

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68bfb3916cec8325a96aa9779d62e876