### PR TITLE
style: add CRT terminal effects and dynamic navigation

### DIFF
--- a/themes/tweed-90s/assets/js/terminal.js
+++ b/themes/tweed-90s/assets/js/terminal.js
@@ -1,4 +1,6 @@
-function typeNode(node, parent, done, speed) {
+let typingSpeed = 20;
+
+function typeNode(node, parent, done) {
   if (node.nodeType === Node.TEXT_NODE) {
     const text = node.textContent;
     let i = 0;
@@ -6,7 +8,7 @@ function typeNode(node, parent, done, speed) {
       if (i < text.length) {
         parent.appendChild(document.createTextNode(text[i]));
         i++;
-        setTimeout(type, speed);
+        setTimeout(type, typingSpeed);
       } else {
         done();
       }
@@ -23,7 +25,7 @@ function typeNode(node, parent, done, speed) {
         typeNode(node.childNodes[i], el, () => {
           i++;
           next();
-        }, speed);
+        });
       } else {
         done();
       }
@@ -33,7 +35,7 @@ function typeNode(node, parent, done, speed) {
   }
 }
 
-function typeWriter(element, speed, callback) {
+function typeWriter(element, callback) {
   const clone = element.cloneNode(true);
   element.innerHTML = "";
   let i = 0;
@@ -42,7 +44,7 @@ function typeWriter(element, speed, callback) {
       typeNode(clone.childNodes[i], element, () => {
         i++;
         next();
-      }, speed);
+      });
     } else if (callback) {
       callback();
     }
@@ -58,10 +60,23 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelector('main'),
     document.querySelector('.site-footer')
   ].filter(Boolean);
+
+  elements.forEach(el => {
+    el.style.minHeight = el.scrollHeight + 'px';
+  });
+
   let index = 0;
+  const updateSpeed = () => {
+    const ratio = window.scrollY / (document.body.scrollHeight - window.innerHeight);
+    typingSpeed = Math.max(2, 20 - ratio * 18);
+  };
+  window.addEventListener('scroll', updateSpeed);
+  updateSpeed();
+
   (function next() {
     if (index < elements.length) {
-      typeWriter(elements[index], 20, () => {
+      typeWriter(elements[index], () => {
+        elements[index].style.minHeight = '';
         index++;
         next();
       });

--- a/themes/tweed-90s/assets/scss/main.scss
+++ b/themes/tweed-90s/assets/scss/main.scss
@@ -10,6 +10,47 @@ body {
   background: #0d0d0d;
   color: #00ff00;
   line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+  animation: flicker 0.15s infinite;
+  transform: perspective(800px) rotateX(1deg) rotateY(-1deg);
+}
+
+body::before {
+  content: "";
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 255, 0, 0.05) 0px,
+    rgba(0, 255, 0, 0.05) 2px,
+    rgba(0, 0, 0, 0.05) 2px,
+    rgba(0, 0, 0, 0.05) 4px
+  );
+  mix-blend-mode: screen;
+  animation: crt-scroll 0.5s linear infinite;
+}
+
+body::after {
+  content: "";
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.4) 100%);
+  transform: scale(1.02);
+}
+
+@keyframes crt-scroll {
+  from { background-position: 0 0; }
+  to { background-position: 0 4px; }
+}
+
+@keyframes flicker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.98; }
+  80% { opacity: 1; }
+  90% { opacity: 0.97; }
 }
 
 .container {
@@ -28,8 +69,16 @@ h2 { font-size: clamp(1.5rem, 5vw, 2.25rem); }
 h3 { font-size: clamp(1.25rem, 4vw, 1.75rem); }
 
 a {
-  color: #00ff00;
+  display: inline-block;
+  padding: 0 0.25em;
+  background: #00ff00;
+  color: #000;
   text-decoration: none;
+}
+
+a:hover {
+  background: transparent;
+  color: #00ff00;
 }
 
 body.retro a {
@@ -69,30 +118,26 @@ textarea:focus-visible {
 
 .site-header .container,
 .site-footer .container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: var(--space-sm) 0;
 }
 
-.nav-details ul {
+.page-nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
-.nav-details[open] ul { display: block; }
-@media (min-width: 48em) {
-  .nav-details {
-    display: block;
-  }
-  .nav-details > summary {
-    display: none;
-  }
-  .nav-details[open] ul,
-  .nav-details ul {
-    display: flex;
-    gap: var(--space-md);
-  }
+
+.page-nav li {
+  flex: 1;
+  text-align: center;
+}
+
+.page-nav li.current {
+  flex: 2;
+  font-size: 1.5em;
 }
 
 main {

--- a/themes/tweed-90s/layouts/partials/site-header.html
+++ b/themes/tweed-90s/layouts/partials/site-header.html
@@ -1,16 +1,13 @@
 <header class="site-header">
   <div class="container">
-    <a class="brand" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
     {{ with .Site.Menus.main }}
-    <nav class="main-nav" aria-label="Primary">
-      <details class="nav-details">
-        <summary>Menu</summary>
-        <ul>
-          {{ range . }}
-            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
-          {{ end }}
-        </ul>
-      </details>
+    <nav class="page-nav" aria-label="Primary">
+      <ul>
+        {{ $current := $.RelPermalink }}
+        {{ range . }}
+          <li class="{{ if eq .URL $current }}current{{ end }}"><a href="{{ .URL }}">{{ .Name }}</a></li>
+        {{ end }}
+      </ul>
     </nav>
     {{ end }}
   </div>


### PR DESCRIPTION
## Summary
- add CRT-style scanlines, flicker, and subtle screen warp
- highlight links Fallout-style and enlarge current page in header nav
- allow scrolling during typing with speed adjusting to scroll position

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo --gc --minify`


------
https://chatgpt.com/codex/tasks/task_e_68bfb560510483259a5f5bb0b0fec3d8