### PR TITLE
Add internal links across site content

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -9,6 +9,8 @@ description: "Fast, accessible web design, hosting, and QA for Northern Rivers b
 
 I’m based in Murwillumbah and work with Northern Rivers clients in person while supporting others remotely.
 
+Browse some [featured sites](/featured-sites) I've worked on.
+
 [Email me](mailto:jordan@tweed.cloud) [Call now](tel:+61406860031) [Contact form](/contact)
 
 ## Services
@@ -20,7 +22,7 @@ I’m based in Murwillumbah and work with Northern Rivers clients in person whil
 - **Accessibility reviews** – WCAG-aware checks for inclusive UX.
 - **SEO setup & on-page** – clean metadata and structure.
 - **Analytics & GTM events** – GA4 and Tag Manager validation.
-- **Consulting** – advice on strategy, tooling, and workflows.
+- **Consulting** – advice on strategy, tooling, and workflows. [Learn more](/consultation)
 
 ## Local
 
@@ -42,6 +44,6 @@ Hugo, Git/GitHub, Lighthouse, Axe, GA4, GTM, Search Console.
 
 ## Ready to start?
 
-[About](/about) · [Contact](/contact)
+[About](/about) · [Consultation](/consultation) · [Featured sites](/featured-sites) · [Contact](/contact)
 
 <!-- TODO: add /services page and link -->

--- a/content/about.md
+++ b/content/about.md
@@ -22,6 +22,8 @@ person:
 
 Hi, I’m Jordan—a web QA specialist on the Gold Coast helping small teams ship fast, accessible and search‑friendly sites.
 
+You can see a few [featured sites](/featured-sites) I've supported or [get in touch](/contact) to chat about your own project.
+
 **Snapshot:** Based in the Tweed region and employed full time at Localsearch, I support businesses and agencies across Australia. My work blends manual testing with data‑driven insights so releases land clean and measurable.
 
 ## What I do now

--- a/content/consultation.md
+++ b/content/consultation.md
@@ -14,7 +14,7 @@ faq:
 ---
 # Consultation
 
-Practical web and IT consulting for Murwillumbah and the Northern Rivers. Get clear, actionable guidance—then the right implementation.
+Practical web and IT consulting for Murwillumbah and the Northern Rivers. Get clear, actionable guidance—then the right implementation. See [featured sites](/featured-sites) for examples of past work.
 
 [Email me](mailto:jordan@tweed.cloud) · [Call now](tel:+61406860031)
 
@@ -78,4 +78,4 @@ After our initial chat we agree on a scope and quote. Payments can be split acro
 
 ## Ready to start?
 
-[Contact me](/contact) · [About me](/about)
+[Contact me](/contact) · [About me](/about) · [Featured sites](/featured-sites)

--- a/content/contact.md
+++ b/content/contact.md
@@ -11,6 +11,8 @@ Phone: [0406860031](tel:0406860031)
 
 Location: Murwillumbah in the Northern Rivers region. I can meet locally or work remotely to assist clients wherever they are.
 
+Learn more [about me](/about), explore [consultation services](/consultation), or browse [featured sites](/featured-sites) to see past work.
+
 ### Social
 - [LinkedIn](https://www.linkedin.com/in/jordan-evans-37a211212)
 - [Instagram](https://www.instagram.com/da_jordo/)

--- a/content/featured-sites.md
+++ b/content/featured-sites.md
@@ -12,3 +12,5 @@ image: "/images/hero-cloud.svg"
 
 [TwiggyPNG](https://twiggyp.ng/) showcases the work of Northern Rivers digital artist Aria Kitchener, creator of the comic "Overgrown" blending Wiradjuri and Bundjalung heritage.
 
+Interested in similar results? [Book a consultation](/consultation) or [get in touch](/contact).
+


### PR DESCRIPTION
## Summary
- Expand site pages with internal links for richer cross-navigation
- Highlight consultation page and featured work from home page
- Reference featured sites and contact options from supporting pages

## Testing
- `hugo --gc --minify`


------
https://chatgpt.com/codex/tasks/task_e_68bfbd257bf883259a6b4b54e4a988e9